### PR TITLE
fix: mixup 수정

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -131,7 +131,7 @@ def ensemble_inference(data_dir, model_dir, output_dir, args):
             preds.extend(list(pred))
 
     info['ans'] = preds
-    save_path = os.path.join(output_dir, args.name_csv+".csv")
+    save_path = os.path.join(output_dir, 'output.csv')
     info.to_csv(save_path, index=False)
     print(f"Inference Done! Inference result saved at {save_path}")
 

--- a/inference.py
+++ b/inference.py
@@ -136,7 +136,7 @@ def ensemble_inference(data_dir, model_dir, output_dir, args):
             preds.extend(list(pred))
 
     info['ans'] = preds
-    save_path = os.path.join(output_dir, 'output.csv')
+    save_path = os.path.join(output_dir, args.name_csv+".csv")
     info.to_csv(save_path, index=False)
     print(f"Inference Done! Inference result saved at {save_path}")
 

--- a/train.py
+++ b/train.py
@@ -272,7 +272,7 @@ def train(data_dir, model_dir, args):
 
                 loss_value = 0
                 matches = 0
-
+            
         if args.scheduler != 'reducelronplateau':
             scheduler.step()
 
@@ -297,7 +297,17 @@ def train(data_dir, model_dir, args):
                 trues += labels.detach().cpu().numpy().tolist()
                 predicts += preds.detach().cpu().numpy().tolist()
                 
-                loss_item = criterion(outs, labels).item()
+                if args.mixup:
+                    t = []
+                    for i in range(args.valid_batch_size):
+                        temp = torch.tensor([0]*num_classes)
+                        temp[labels[i]] = 1.0
+                        t.append(temp)
+                    labels = torch.stack(t).to(device).float()
+                    loss_item = criterion(outs, labels).item()
+                    labels = torch.argmax(labels,dim=-1)
+                else:
+                    loss_item = criterion(outs, labels).item()
                 acc_item = (labels == preds).sum().item()
                 val_loss_items.append(loss_item)
                 val_acc_items.append(acc_item)


### PR DESCRIPTION
## Overview
- mixup 코드 수정
    
## Change Log
- train.py val loop에 mixup label 코드 수정
- 라벨을 벡터로 만들어 criterion bce 계산이 가능하도록
    
## To Reviewer    
- train.py 코드 label 수정했습니다.
    
## Issue Tags
- close #65 
